### PR TITLE
feat: Component Testing Framework Baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "build": "node scripts/build.js",
     "build-scss": "sass ./styles/style.scss ./dist/styles/main.css",
     "minify": "find dist -name '*.js' -exec terser {} --compress drop_console=true --mangle --output {} \\;",
-    "pub": "node scripts/build.js && npm run minify && cd dist && npm publish --access public"
+    "pub": "node scripts/build.js && npm run minify && cd dist && npm publish --access public",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "exports": {
     ".": {
@@ -45,10 +47,12 @@
   "devDependencies": {
     "@types/node": "^24.3.3",
     "csstype": "^3.1.3",
+    "happy-dom": "^17.0.0",
     "sass": "^1.93.3",
     "terser": "^5.44.0",
     "typescript": "^5.9.2",
-    "vite": "^7.1.5"
+    "vite": "^7.1.5",
+    "vitest": "^3.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -1,26 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { DivElement, SpanElement } from '../src';
+import { render } from './utils';
 
 describe('TypeComposer Component Rendering', () => {
   it('should render a DivElement and set its text content', () => {
-    // Create an instance of DivElement
-    const div = new DivElement({ text: 'Hello, TypeComposer!' });
+    // Create and mount the DivElement using our rendering utility
+    const div = render(new DivElement({ text: 'Hello, TypeComposer!' }));
 
     // Verify it is a Div element and text is set correctly
     expect(div).toBeInstanceOf(window.HTMLDivElement);
     expect(div.textContent).toBe('Hello, TypeComposer!');
+    expect(document.body.contains(div)).toBe(true);
   });
 
   it('should render a SpanElement with styles', () => {
-    // Create an instance of SpanElement with text and styles
-    const span = new SpanElement({
+    // Create and mount the SpanElement with text and styles
+    const span = render(new SpanElement({
       text: 'Styled Span',
       style: { color: 'rgb(255, 0, 0)', fontWeight: 'bold' }
-    });
+    }));
 
     expect(span).toBeInstanceOf(window.HTMLSpanElement);
     expect(span.textContent).toBe('Styled Span');
     expect(span.style.color).toBe('rgb(255, 0, 0)');
     expect(span.style.fontWeight).toBe('bold');
+    expect(document.body.contains(span)).toBe(true);
   });
 });

--- a/tests/component.test.ts
+++ b/tests/component.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { DivElement, SpanElement } from '../src';
+
+describe('TypeComposer Component Rendering', () => {
+  it('should render a DivElement and set its text content', () => {
+    // Create an instance of DivElement
+    const div = new DivElement({ text: 'Hello, TypeComposer!' });
+
+    // Verify it is a Div element and text is set correctly
+    expect(div).toBeInstanceOf(window.HTMLDivElement);
+    expect(div.textContent).toBe('Hello, TypeComposer!');
+  });
+
+  it('should render a SpanElement with styles', () => {
+    // Create an instance of SpanElement with text and styles
+    const span = new SpanElement({
+      text: 'Styled Span',
+      style: { color: 'rgb(255, 0, 0)', fontWeight: 'bold' }
+    });
+
+    expect(span).toBeInstanceOf(window.HTMLSpanElement);
+    expect(span.textContent).toBe('Styled Span');
+    expect(span.style.color).toBe('rgb(255, 0, 0)');
+    expect(span.style.fontWeight).toBe('bold');
+  });
+});

--- a/tests/reactivity.test.ts
+++ b/tests/reactivity.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref, computed } from '../src';
+
+describe('TypeComposer Reactivity', () => {
+  it('should initialize refs with primitive values', () => {
+    const stringRef = ref('Hello');
+    const numberRef = ref(42);
+    const booleanRef = ref(true);
+
+    expect(stringRef.value).toBe('Hello');
+    expect(numberRef.value).toBe(42);
+    expect(booleanRef.value).toBe(true);
+  });
+
+  it('should trigger subscriptions on value changes', () => {
+    const stringRef = ref('Hello');
+    const listener = vi.fn();
+
+    stringRef.subscribe(listener);
+
+    // Initial subscription triggers immediately
+    expect(listener).toHaveBeenCalledWith('Hello', 'Hello');
+
+    stringRef.value = 'World';
+    expect(listener).toHaveBeenLastCalledWith('World', 'Hello');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('should support computed derived values using observers', () => {
+    const first = ref('John');
+    const last = ref('Doe');
+
+    // Using the observers collection passed to the callback to put/track dependencies
+    const full = computed((obs) => {
+      const f = obs.put(first);
+      const l = obs.put(last);
+      return `${f} ${l}`;
+    });
+
+    expect(full.value).toBe('John Doe');
+
+    first.value = 'Jane';
+    expect(full.value).toBe('Jane Doe');
+
+    last.value = 'Smith';
+    expect(full.value).toBe('Jane Smith');
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,23 @@
+import { afterEach } from 'vitest';
+
+const mountedComponents = new Set<HTMLElement>();
+
+/**
+ * Renders a component by appending it to document.body.
+ * Keeps track of mounted elements to clean them up after each test.
+ */
+export function render<T extends HTMLElement>(component: T): T {
+  document.body.appendChild(component);
+  mountedComponents.add(component);
+  return component;
+}
+
+afterEach(() => {
+  for (const component of mountedComponents) {
+    if (component.parentNode) {
+      component.remove();
+    }
+  }
+  mountedComponents.clear();
+  document.body.innerHTML = '';
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
This pull request introduces the first baseline for the roadmap's "Component Testing Framework" item for TypeComposer.

### Summary of Changes:
- **Vitest & Happy DOM Integration:** Configured Vitest as the lightweight, fast test runner natively integrated with Vite, paired with `happy-dom` for standard and high-performance Custom Elements / Web Components rendering support.
- **Test Scripts:** Added `npm run test` and `npm run test:run` in `package.json`.
- **Tiny & Reusable Testing Utility:** Created a light `render` helper in `tests/utils.ts` that mounts components to the DOM during test execution and registers an `afterEach` hook to automatically clean them up between tests.
- **Reactivity Baseline Tests (`tests/reactivity.test.ts`):** Covered primitive reactive refs (`ref`) and computed dependency tracking (`computed`).
- **Component Rendering Tests (`tests/component.test.ts`):** Verified rendering of customized built-in elements (`DivElement` and `SpanElement`) along with text and style properties.

### Findings on GitHub Actions Workflows:
An attempt was made to add a `.github/workflows/ci.yml` CI pipeline to trigger on push and pull requests, but this action was blocked due to the default integration token not having the `workflow` scope. Adding the CI workflow is highly recommended as a next step when merging.