### PR TITLE
test: expand component and reactivity examples

### DIFF
--- a/tests/composition.test.ts
+++ b/tests/composition.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { DivElement, SpanElement, ButtonElement, HBox, VBox } from '../src';
+import { render } from './utils';
+
+describe('TypeComposer component composition and nesting', () => {
+  describe('DivElement with child SpanElement', () => {
+    it('should nest a SpanElement inside a DivElement', () => {
+      const span = new SpanElement({ text: 'inner' });
+      const div = render(new DivElement({ children: [span] }));
+
+      expect(div).toBeInstanceOf(window.HTMLDivElement);
+      expect(div.contains(span)).toBe(true);
+      expect(span.textContent).toBe('inner');
+    });
+
+    it('should allow multiple children in a DivElement', () => {
+      const span1 = new SpanElement({ text: 'first' });
+      const span2 = new SpanElement({ text: 'second' });
+      const div = render(new DivElement({ children: [span1, span2] }));
+
+      expect(div.childElementCount).toBe(2);
+      expect(div.children[0].textContent).toBe('first');
+      expect(div.children[1].textContent).toBe('second');
+    });
+  });
+
+  describe('HBox layout composition', () => {
+    it('should render HBox and contain appended children', () => {
+      const spanA = new SpanElement({ text: 'A' });
+      const spanB = new SpanElement({ text: 'B' });
+      const hbox = render(new HBox({ children: [spanA, spanB] }));
+
+      expect(hbox).toBeInstanceOf(window.HTMLElement);
+      expect(hbox.contains(spanA)).toBe(true);
+      expect(hbox.contains(spanB)).toBe(true);
+    });
+
+    it('should be present in document body after render', () => {
+      const hbox = render(new HBox({ children: [new SpanElement({ text: 'Hi' })] }));
+      expect(document.body.contains(hbox)).toBe(true);
+    });
+  });
+
+  describe('VBox layout composition', () => {
+    it('should render VBox with stacked children', () => {
+      const item1 = new DivElement({ text: 'Row 1' });
+      const item2 = new DivElement({ text: 'Row 2' });
+      const vbox = render(new VBox({ children: [item1, item2] }));
+
+      expect(vbox).toBeInstanceOf(window.HTMLElement);
+      expect(vbox.contains(item1)).toBe(true);
+      expect(vbox.contains(item2)).toBe(true);
+      expect(item1.textContent).toBe('Row 1');
+      expect(item2.textContent).toBe('Row 2');
+    });
+  });
+
+  describe('HBox nested inside VBox', () => {
+    it('should support HBox inside VBox (two-level nesting)', () => {
+      const label = new SpanElement({ text: 'label' });
+      const hbox = new HBox({ children: [label] });
+      const vbox = render(new VBox({ children: [hbox] }));
+
+      expect(vbox.contains(hbox)).toBe(true);
+      expect(hbox.contains(label)).toBe(true);
+      expect(label.textContent).toBe('label');
+    });
+  });
+
+  describe('ButtonElement inside a container', () => {
+    it('should render a ButtonElement inside a DivElement', () => {
+      const btn = new ButtonElement({ text: 'Click me' });
+      const container = render(new DivElement({ children: [btn] }));
+
+      expect(container.contains(btn)).toBe(true);
+      expect(btn).toBeInstanceOf(window.HTMLButtonElement);
+      expect(btn.textContent).toBe('Click me');
+    });
+  });
+
+  describe('style propagation on nested elements', () => {
+    it('should apply style to a SpanElement nested in DivElement', () => {
+      const span = new SpanElement({
+        text: 'styled child',
+        style: { color: 'rgb(0, 128, 0)', fontSize: '14px' },
+      });
+      const div = render(new DivElement({ children: [span] }));
+
+      expect(div.contains(span)).toBe(true);
+      expect(span.style.color).toBe('rgb(0, 128, 0)');
+      expect(span.style.fontSize).toBe('14px');
+    });
+  });
+});

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ButtonElement, DivElement, SpanElement } from '../src';
+import { EventComponent } from '../src/core/event';
+import { render } from './utils';
+
+describe('TypeComposer event binding', () => {
+  describe('native DOM events via addEventListener', () => {
+    it('should fire a click listener attached to ButtonElement', () => {
+      const btn = render(new ButtonElement({ text: 'Press' }));
+      const handler = vi.fn();
+
+      btn.addEventListener('click', handler);
+      btn.click();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fire a click listener multiple times on multiple clicks', () => {
+      const btn = render(new ButtonElement({ text: 'Multi' }));
+      const handler = vi.fn();
+
+      btn.addEventListener('click', handler);
+      btn.click();
+      btn.click();
+      btn.click();
+
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it('should stop firing after removeEventListener', () => {
+      const btn = render(new ButtonElement({ text: 'Remove' }));
+      const handler = vi.fn();
+
+      btn.addEventListener('click', handler);
+      btn.click();
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      btn.removeEventListener('click', handler);
+      btn.click();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('native click on DivElement', () => {
+    it('should fire a click event on a DivElement', () => {
+      const div = render(new DivElement({ text: 'Clickable Div' }));
+      const handler = vi.fn();
+
+      div.addEventListener('click', handler);
+      div.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('event bubbling from child to parent', () => {
+    it('should bubble a click from SpanElement up to a containing DivElement', () => {
+      const span = new SpanElement({ text: 'inner' });
+      const div = render(new DivElement({ children: [span] }));
+      const handler = vi.fn();
+
+      div.addEventListener('click', handler);
+      span.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not bubble when bubbles is false', () => {
+      const span = new SpanElement({ text: 'no-bubble' });
+      const div = render(new DivElement({ children: [span] }));
+      const handler = vi.fn();
+
+      div.addEventListener('click', handler);
+      span.dispatchEvent(new MouseEvent('click', { bubbles: false }));
+
+      expect(handler).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('EventComponent pub/sub system', () => {
+    it('should emit and receive a custom event', () => {
+      const listener = vi.fn();
+      const container = render(new DivElement());
+
+      // Create the event channel first with initial data, then subscribe;
+      // because isInit is true, the listener fires immediately on addEventListener
+      EventComponent.createEvent('test:greet', 'world');
+      EventComponent.addEventListener(container as any, 'test:greet', listener);
+
+      expect(listener).toHaveBeenCalledWith('world');
+
+      // Emit again with new data
+      EventComponent.emitEvent('test:greet', 'again');
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith('again');
+
+      // Clean up global event channel to avoid cross-test pollution
+      EventComponent.deleteEvent('test:greet');
+    });
+
+    it('should create an event channel without initial data and receive emits', () => {
+      const listener = vi.fn();
+      const container = render(new DivElement());
+
+      // No data passed → isInit stays false → listener must NOT fire immediately
+      EventComponent.createEvent('test:ping');
+      EventComponent.addEventListener(container as any, 'test:ping', listener);
+
+      expect(listener).not.toHaveBeenCalled();
+
+      EventComponent.emitEvent('test:ping', 42);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(42);
+
+      EventComponent.deleteEvent('test:ping');
+    });
+
+    it('should stop receiving events after removeEventListener', () => {
+      const listener = vi.fn();
+      const container = render(new DivElement());
+
+      EventComponent.createEvent('test:bye');
+      EventComponent.addEventListener(container as any, 'test:bye', listener);
+
+      EventComponent.emitEvent('test:bye', 'hello');
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      EventComponent.removeEventListener(container as any, 'test:bye');
+      EventComponent.emitEvent('test:bye', 'ignored');
+
+      // Count must stay at 1 after removal
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      EventComponent.deleteEvent('test:bye');
+    });
+
+    it('should support multiple subscribers on the same event channel', () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      const el1 = render(new DivElement());
+      const el2 = render(new DivElement());
+
+      EventComponent.createEvent('test:broadcast');
+      EventComponent.addEventListener(el1 as any, 'test:broadcast', listener1);
+      EventComponent.addEventListener(el2 as any, 'test:broadcast', listener2);
+
+      EventComponent.emitEvent('test:broadcast', 'ping');
+
+      expect(listener1).toHaveBeenCalledWith('ping');
+      expect(listener2).toHaveBeenCalledWith('ping');
+
+      EventComponent.deleteEvent('test:broadcast');
+    });
+  });
+});

--- a/tests/reactivity-computed.test.ts
+++ b/tests/reactivity-computed.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref, computed } from '../src';
+
+describe('Computed chains and advanced reactivity', () => {
+  describe('chained computed refs', () => {
+    it('should propagate through a two-level computed chain', () => {
+      const base = ref(2);
+
+      const doubled = computed((obs) => {
+        const b = obs.put(base);
+        return b * 2;
+      });
+
+      const quadrupled = computed((obs) => {
+        const d = obs.put(doubled);
+        return d * 2;
+      });
+
+      expect(doubled.value).toBe(4);
+      expect(quadrupled.value).toBe(8);
+
+      base.value = 5;
+      expect(doubled.value).toBe(10);
+      expect(quadrupled.value).toBe(20);
+    });
+
+    it('should recompute when any upstream ref changes in a multi-dep computed', () => {
+      const a = ref(1);
+      const b = ref(10);
+      const c = ref(100);
+
+      const sum = computed((obs) => {
+        return obs.put(a) + obs.put(b) + obs.put(c);
+      });
+
+      expect(sum.value).toBe(111);
+
+      a.value = 2;
+      expect(sum.value).toBe(112);
+
+      b.value = 20;
+      expect(sum.value).toBe(122);
+
+      c.value = 200;
+      expect(sum.value).toBe(222);
+    });
+
+    it('should notify a subscriber on each computed recomputation', () => {
+      const price = ref(10);
+      const quantity = ref(3);
+
+      const total = computed((obs) => obs.put(price) * obs.put(quantity));
+
+      const listener = vi.fn();
+      total.subscribe(listener);
+
+      // subscribe immediately emits the current value
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(30, 30);
+
+      price.value = 20;
+      expect(total.value).toBe(60);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(60, 30);
+
+      quantity.value = 5;
+      expect(total.value).toBe(100);
+      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenLastCalledWith(100, 60);
+    });
+  });
+
+  describe('ref.update helper', () => {
+    it('should update a number ref via updater function', () => {
+      const count = ref(0);
+      count.update((n) => n + 1);
+      expect(count.value).toBe(1);
+      count.update((n) => n * 3);
+      expect(count.value).toBe(3);
+    });
+
+    it('should update a string ref via updater function', () => {
+      const label = ref('hello');
+      label.update((s) => s.toUpperCase());
+      expect(label.value).toBe('HELLO');
+    });
+
+    it('should update a number ref by direct value', () => {
+      const count = ref(5);
+      count.update(99);
+      expect(count.value).toBe(99);
+    });
+  });
+
+  describe('ref.listen (no immediate emission)', () => {
+    it('should not fire the listener on initial subscription', () => {
+      const name = ref('Alice');
+      const listener = vi.fn();
+
+      name.listen(listener);
+      expect(listener).not.toHaveBeenCalled();
+
+      name.value = 'Bob';
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith('Bob', 'Alice');
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('should stop firing after unsubscribe', () => {
+      const counter = ref(0);
+      const listener = vi.fn();
+
+      counter.subscribe(listener);
+      expect(listener).toHaveBeenCalledTimes(1); // immediate emit
+
+      counter.value = 1;
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      counter.unsubscribe(listener);
+
+      counter.value = 2;
+      // no additional calls after unsubscribe
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('computed with boolean ref', () => {
+    it('should derive a string label from a boolean toggle', () => {
+      const isActive = ref(false);
+
+      const label = computed((obs) => (obs.put(isActive) ? 'active' : 'inactive'));
+
+      expect(label.value).toBe('inactive');
+
+      isActive.value = true;
+      expect(label.value).toBe('active');
+
+      isActive.value = false;
+      expect(label.value).toBe('inactive');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follows up on the PR #13 Component Testing Framework baseline by expanding test coverage into three new areas: computed chains, nested component composition, and event binding.

### What changed

**`tests/reactivity-computed.test.ts`** (9 tests — _new file_)
- Two-level chained computed propagation (`base → doubled → quadrupled`)
- Multi-dependency computed recomputation (3 upstream refs)
- Subscriber notification on each computed recomputation (with call-count and value assertions)
- `ref.update()` via updater function and direct value (number + string)
- `ref.listen()` — verifies no immediate emission, only future changes
- `unsubscribe()` — verifies notifications stop after removal
- Computed from a boolean ref (derived label string)

**`tests/composition.test.ts`** (8 tests — _new file_)
- `SpanElement` nested inside `DivElement` (single and multiple children)
- `HBox` with appended children, verified in `document.body`
- `VBox` with stacked children
- `HBox` nested inside `VBox` (two-level nesting)
- `ButtonElement` inside a `DivElement` container
- Style propagation on a nested `SpanElement`

**`tests/events.test.ts`** (10 tests — _new file_)
- Native `addEventListener` / `removeEventListener` on `ButtonElement` (fire once, multiple clicks, removal stops firing)
- Native `click` event on `DivElement` via `dispatchEvent`
- Event bubbling: `bubbles: true` propagates to parent; `bubbles: false` does not
- `EventComponent` pub/sub: `createEvent` with initial data fires listener immediately; without data it does not
- `EventComponent` `removeEventListener` stops future deliveries
- `EventComponent` multiple subscribers on the same channel both receive the emit

### Validation

```
npm run test:run
```

```
 ✓ tests/events.test.ts (10 tests) 21ms
 ✓ tests/composition.test.ts (8 tests) 20ms
 ✓ tests/reactivity-computed.test.ts (9 tests) 11ms
 ✓ tests/component.test.ts (2 tests) 10ms
 ✓ tests/reactivity.test.ts (3 tests) 7ms

 Test Files  5 passed (5)
      Tests  32 passed (32)
```

```
npm run build
```
✅ Build passes (tsc + Sass + dist assembly).

### Notes / caveats

- `EventComponent` is imported directly from `../src/core/event` because it is not re-exported by `src/index.ts`. This is intentional and avoids any public API changes — if `EventComponent` is promoted to the public surface later, the import path can be updated.
- The `onclick` prop on `ButtonElement` (set via constructor options) is deliberately not tested here because `applyProps` is `async` — attempting `btn.click()` immediately after construction produces a race condition. The recommended pattern for synchronous test assertions is `addEventListener`, which is covered. This is documented in the commit message.
- No production source files were modified — this PR is tests only.

Roadmap alignment: **Testing utilities and example tests**.

cc @zico15