### PR TITLE
fix: remove production console.log from RefObject proxy setter

### DIFF
--- a/src/core/ref/RefObject.ts
+++ b/src/core/ref/RefObject.ts
@@ -145,9 +145,6 @@ function createObservador<T extends object>(obj: T, container: RefObjectContaine
         receiver = Reflect.set(target, key, value, receiver);
       }
       if (!isNotEmitted && !(target[key] !== null && typeof target[key] === "object" && Object.getPrototypeOf(target[key]) === Object.prototype)) {
-        console.log("RefObject: emit", {
-          key, value, target, receiver
-        });
         container.emitAll('value', this.value);
       }
       return receiver;

--- a/tests/reactive-collections.test.ts
+++ b/tests/reactive-collections.test.ts
@@ -433,3 +433,44 @@ describe('ref() factory – collection dispatch', () => {
     expect((r as RefMap<string, number>).get('n')).toBe(42);
   });
 });
+// ─── RefObject console.log regression (audit item 1) ─────────────────────────
+
+describe('RefObject – no console.log in production', () => {
+  it('nested property mutation does NOT call console.log', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const obj = ref({ name: 'Alice', age: 30 });
+      // mutate a nested property via the proxy setter
+      (obj.value as any).name = 'Bob';
+      (obj.value as any).age = 31;
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('update() does NOT call console.log', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const obj = ref({ count: 0 });
+      obj.update({ count: 5 });
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('subscriber is still notified after property mutation without console.log', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const obj = ref({ x: 10 });
+      let notified = false;
+      obj.listen(() => { notified = true; });
+      (obj.value as any).x = 99;
+      expect(notified).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Removes a debug `console.log("RefObject: emit", ...)` that was accidentally left in the `createObservador()` Proxy `set` trap inside `src/core/ref/RefObject.ts`.  
The log fired on **every nested object property mutation**, leaking internal reactive state (`{ key, value, target, receiver }`) to production consoles.

**File changed:** `src/core/ref/RefObject.ts`

```diff
-        console.log("RefObject: emit", {
-          key, value, target, receiver
-        });
         container.emitAll('value', this.value);
```

---

## Regression tests added

Three new tests in `tests/reactive-collections.test.ts` (describe: *RefObject – no console.log in production*):

| Test | Asserts |
|---|---|
| `nested property mutation does NOT call console.log` | proxy setter fires without calling `console.log` |
| `update() does NOT call console.log` | `obj.update({...})` fires without calling `console.log` |
| `subscriber is still notified after property mutation without console.log` | reactivity still works (listen callback fires), no log |

---

## Validation

```
npm run test:run   →  9 test files, 165 tests passed  ✓
npx tsc --noEmit   →  no errors  ✓
```

---

## Roadmap alignment

Addresses **audit item 1** from the PR #15 review. Small, focused, no architectural change.

Reviewer: @zico15