### PR TITLE
fix: correct CheckBoxGroup sibling deselection querySelector selector

### DIFF
--- a/src/core/components/check-box/CheckBox.ts
+++ b/src/core/components/check-box/CheckBox.ts
@@ -96,7 +96,7 @@ export class CheckBoxGroup extends Component {
     if (checkbox.checked) {
       this._selected = checkbox;
       this.onChange(checkbox);
-      this.querySelectorAll("check-box").forEach((cb) => {
+      this.querySelectorAll(CheckBox.TAG).forEach((cb) => {
         if (cb !== checkbox) {
           (cb as CheckBox).checked = false;
         }

--- a/tests/forms.test.ts
+++ b/tests/forms.test.ts
@@ -251,3 +251,73 @@ describe('SwitchPanel', () => {
     expect(sw.checked).toBe(false);
   });
 });
+// ─── CheckBoxGroup sibling deselection regression (audit item 2) ─────────────
+
+describe('CheckBoxGroup – sibling deselection', () => {
+  it('checking one sibling deselects the previously checked sibling', () => {
+    const cb1 = new CheckBox({ label: 'Option 1' });
+    const cb2 = new CheckBox({ label: 'Option 2' });
+    const grp = render(new CheckBoxGroup(cb1, cb2));
+
+    // Check cb1 first
+    cb1.checked = true;
+    cb1.dispatchEvent(new Event('change', { bubbles: false }));
+
+    // Now check cb2 — cb1 should become unchecked
+    cb2.checked = true;
+    cb2.dispatchEvent(new Event('change', { bubbles: false }));
+
+    expect(cb2.checked).toBe(true);
+    expect(cb1.checked).toBe(false);
+    expect(grp.selected).toBe(cb2);
+  });
+
+  it('checking three siblings leaves only the last checked as selected', () => {
+    const cb1 = new CheckBox({ label: 'A' });
+    const cb2 = new CheckBox({ label: 'B' });
+    const cb3 = new CheckBox({ label: 'C' });
+    const grp = render(new CheckBoxGroup(cb1, cb2, cb3));
+
+    cb1.checked = true;
+    cb1.dispatchEvent(new Event('change', { bubbles: false }));
+    cb2.checked = true;
+    cb2.dispatchEvent(new Event('change', { bubbles: false }));
+    cb3.checked = true;
+    cb3.dispatchEvent(new Event('change', { bubbles: false }));
+
+    expect(cb3.checked).toBe(true);
+    expect(cb2.checked).toBe(false);
+    expect(cb1.checked).toBe(false);
+    expect(grp.selected).toBe(cb3);
+  });
+
+  it('unchecking the selected item clears grp.selected', () => {
+    const cb1 = new CheckBox({ label: 'X' });
+    const grp = render(new CheckBoxGroup(cb1));
+
+    cb1.checked = true;
+    cb1.dispatchEvent(new Event('change', { bubbles: false }));
+    expect(grp.selected).toBe(cb1);
+
+    cb1.checked = false;
+    cb1.dispatchEvent(new Event('change', { bubbles: false }));
+    expect(grp.selected).toBeNull();
+  });
+
+  it('onChange fires with the correct CheckBox reference when sibling deselects', () => {
+    const cb1 = new CheckBox({ label: 'P' });
+    const cb2 = new CheckBox({ label: 'Q' });
+    const grp = render(new CheckBoxGroup(cb1, cb2));
+    const received: CheckBox[] = [];
+    grp.onChange = (cb) => received.push(cb);
+
+    cb1.checked = true;
+    cb1.dispatchEvent(new Event('change', { bubbles: false }));
+    cb2.checked = true;
+    cb2.dispatchEvent(new Event('change', { bubbles: false }));
+
+    // onChange should have fired for both checkboxes that were checked
+    expect(received.length).toBeGreaterThanOrEqual(2);
+    expect(received[received.length - 1]).toBe(cb2);
+  });
+});


### PR DESCRIPTION
## Summary

`CheckBoxGroup.change()` used `"check-box"` as a CSS selector to find sibling checkboxes to deselect.  
`"check-box"` is not a valid custom element name and matches nothing in the DOM — so siblings were **never deselected** when a new checkbox was checked.

The correct selector is `CheckBox.TAG` (`"tc-check-box"`).

**File changed:** `src/core/components/check-box/CheckBox.ts`

```diff
-      this.querySelectorAll("check-box").forEach((cb) => {
+      this.querySelectorAll(CheckBox.TAG).forEach((cb) => {
```

---

## Regression tests added

Four new tests in `tests/forms.test.ts` (describe: *CheckBoxGroup – sibling deselection*):

| Test | Asserts |
|---|---|
| checking one sibling deselects the previously checked sibling | `cb1.checked === false` after `cb2` is checked |
| three-sibling rotation | only last checked sibling remains checked |
| unchecking selected item clears `grp.selected` | `grp.selected === null` |
| `onChange` fires with correct reference when sibling deselects | `onChange` callback receives the newly checked checkbox |

---

## Validation

```
npm run test:run   →  9 test files, 166 tests passed  ✓
npx tsc --noEmit   →  no errors  ✓
```

---

## Roadmap alignment

Addresses **audit item 2**. Single-line source fix + targeted regression suite.

Reviewer: @zico15