### PR TITLE
fix: preserve queryParams in memory/static/abstract Router mode

### DIFF
--- a/src/core/router/Router.ts
+++ b/src/core/router/Router.ts
@@ -416,7 +416,8 @@ export class Router {
       window.location.hash = newUrl;
     } else {
       // For memory, static, and abstract modes, update internal state and trigger route handling
-      Router.#router.url = url;
+      // Include query params in the internal URL so handleRoute() / getRouterParams() can parse them.
+      Router.#router.url = newUrl;
       Router.#router.#props = extras?.queryParams || {};
       Router.#router.handleRoute();
     }

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -116,3 +116,33 @@ describe('Router – utility methods', () => {
     warnSpy.mockRestore();
   });
 });
+// ─── Query parameters preservation (audit item 3) ────────────────────────────
+
+describe('Router – queryParams in memory mode', () => {
+  it('single query param: Router.props has { q: "hello" } after go("/search", { queryParams: { q: "hello" } })', async () => {
+    await Router.go('/search', { queryParams: { q: 'hello' } });
+    expect(Router.props).toMatchObject({ q: 'hello' });
+  });
+
+  it('multiple query params are all preserved in Router.props', async () => {
+    await Router.go('/search', { queryParams: { q: 'test', page: '2', sort: 'asc' } });
+    expect(Router.props).toMatchObject({ q: 'test', page: '2', sort: 'asc' });
+  });
+
+  it('navigating without queryParams yields empty Router.props', async () => {
+    await Router.go('/search');
+    expect(Router.props).toEqual({});
+  });
+
+  it('empty queryParams object yields empty Router.props', async () => {
+    await Router.go('/search', { queryParams: {} });
+    expect(Router.props).toEqual({});
+  });
+
+  it('queryParams do not bleed into the next navigation without params', async () => {
+    await Router.go('/search', { queryParams: { q: 'bleed' } });
+    expect(Router.props).toMatchObject({ q: 'bleed' });
+    await Router.go('/about');
+    expect(Router.props).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

In `Router.go()`, the `memory` / `static` / `abstract` branch stored only the **bare pathname** in `this.url` before calling `handleRoute()`.  
Because `handleRoute()` constructs a `URL` object from `this.url`, it received no query string — so `getRouterParams()` found nothing in `url.searchParams`, and `Router.props` was always `{}` even when `queryParams` were passed.

The fix is one line: pass `newUrl` (which `buildURL` already appends `?key=value` to) instead of the raw `url`.

**File changed:** `src/core/router/Router.ts`

```diff
  } else {
    // For memory, static, and abstract modes, update internal state and trigger route handling
-   Router.#router.url = url;
+   // Include query params in the internal URL so handleRoute() / getRouterParams() can parse them.
+   Router.#router.url = newUrl;
    Router.#router.#props = extras?.queryParams || {};
    Router.#router.handleRoute();
  }
```

`handleRoute()` already calls `new URL("http://localhost" + urlPath)` and stores only `url.pathname` back into `this.url`, so `Router.pathname` is unaffected.  
`getRouterParams()` already iterates `url.searchParams`, so no further changes are needed there.

---

## Regression tests added

Five new tests in `tests/router.test.ts` (describe: *Router – queryParams in memory mode*):

| Test | Asserts |
|---|---|
| single query param | `Router.props` contains `{ q: 'hello' }` |
| multiple query params | all three params present in `Router.props` |
| no queryParams arg | `Router.props === {}` |
| empty queryParams object | `Router.props === {}` |
| params don't bleed into next navigation | after navigating away without params, `Router.props === {}` |

---

## Validation

```
npm run test:run   →  9 test files, 167 tests passed  ✓
npx tsc --noEmit   →  no errors  ✓
```

---

## Roadmap alignment

Addresses **audit item 3**. Minimal one-line source fix with full query-param regression suite.

Reviewer: @zico15