### PR TITLE
test: strengthen RefObject assertions in reactive-collections.test.ts

### DIFF
--- a/tests/reactive-collections.test.ts
+++ b/tests/reactive-collections.test.ts
@@ -351,15 +351,18 @@ describe('RefMap – reactivity (subscribe / listen / unsubscribe)', () => {
 // ─── RefObject ────────────────────────────────────────────────────────────────
 
 describe('RefObject (refObject)', () => {
-  it('creates a reactive object wrapper', () => {
+  it('creates a reactive object wrapper with a non-empty id string', () => {
     const obj = refObject({ name: 'Alice', age: 30 });
-    expect(obj).toBeTruthy();
-    expect(obj.id).toBeTruthy();
+    expect(typeof obj.id).toBe('string');
+    expect(obj.id.length).toBeGreaterThan(0);
+    expect(typeof obj.subscribe).toBe('function');
+    expect(typeof obj.update).toBe('function');
   });
 
-  it('value exposes the wrapped plain object', () => {
+  it('value exposes the wrapped plain object with the correct keys', () => {
     const obj = refObject({ x: 1 });
-    expect(obj.value).toBeTruthy();
+    expect(obj.value).toBeDefined();
+    expect((obj.value as any).x).toBe(1);
   });
 
   it('subscribe emits immediately', () => {
@@ -369,12 +372,17 @@ describe('RefObject (refObject)', () => {
     expect(called).toBe(true);
   });
 
-  it('update with new plain object replaces content', () => {
+  it('update with new plain object replaces content and notifies subscriber', () => {
     const obj = refObject({ a: 1 });
+    let callCount = 0;
     let lastValue: any = null;
-    obj.subscribe((v) => { lastValue = v; });
+    obj.subscribe((v) => { callCount++; lastValue = v; });
+    // subscribe fires immediately (callCount == 1)
+    const baseCalls = callCount;
     obj.update({ b: 2 });
-    expect(lastValue).toBeTruthy();
+    expect(callCount).toBeGreaterThan(baseCalls);
+    expect(lastValue).toBeDefined();
+    expect(typeof lastValue).toBe('object');
   });
 
   it('listen does not emit immediately', () => {
@@ -403,10 +411,13 @@ describe('RefObject (refObject)', () => {
     expect(calls).toBe(base);
   });
 
-  it('toJSON serializes the object value', () => {
-    const obj = refObject({ key: 'value' });
-    const json = obj.toJSON();
+  it('toJSON serializes the object value to a plain object matching the source keys', () => {
+    const obj = refObject({ key: 'value', count: 42 });
+    const json = obj.toJSON() as any;
     expect(typeof json).toBe('object');
+    expect(json).not.toBeNull();
+    expect(json.key).toBe('value');
+    expect(json.count).toBe(42);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #15 — replaces four weak `toBeTruthy()` / `typeof`-only assertions in the `RefObject (refObject)` describe block with exact behavioral assertions that would catch real regressions.

**File changed:** `tests/reactive-collections.test.ts` (test-only change, no production code modified)

| Old assertion (weak) | New assertion (exact) |
|---|---|
| `expect(obj).toBeTruthy()` | `expect(typeof obj.id).toBe('string')` + `id.length > 0` + `subscribe`/`update` are functions |
| `expect(obj.value).toBeTruthy()` | `expect((obj.value as any).x).toBe(1)` — checks actual wrapped value |
| `expect(lastValue).toBeTruthy()` after update | counts subscriber calls (> baseCalls) and checks `lastValue` is a defined object |
| `expect(typeof json).toBe('object')` | checks `json.key === 'value'` and `json.count === 42` — verifies serialized shape |

---

## Validation

```
npm run test:run   →  9 test files, 162 tests passed  ✓
npx tsc --noEmit   →  no errors  ✓
```

---

## Roadmap alignment

Addresses **audit item 8** (strengthen weak RefObject test assertions). No production code changed.

Reviewer: @zico15